### PR TITLE
Add Supabase & Pica env placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,17 @@
 # OpenAI API Key for AI invoice processing
 OPENAI_API_KEY=your_openai_api_key_here
 
+# The following environment variables must be populated with your
+# actual project credentials for the application to function.
+
+# Supabase configuration
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
+SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key_here
+
+# Pica configuration
+PICA_SECRET_KEY=your_pica_secret_key_here
+PICA_STRIPE_CONNECTION_KEY=your_pica_stripe_connection_key_here
+
 # Set to true in development environment
 NEXT_PUBLIC_TEMPO=true

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,14 @@
 # Production environment variables
 NEXT_PUBLIC_SITE_URL=https://nouvoice.com.au
+
+# The following environment variables must be populated with your
+# actual project credentials for the application to function.
+
+# Supabase configuration
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Pica configuration
+PICA_SECRET_KEY=
+PICA_STRIPE_CONNECTION_KEY=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+## Environment Variables
+
+Copy `.env.example` to `.env` and replace the placeholder values with your
+project's actual credentials. The following keys are required for the
+application to function:
+
+```
+NEXT_PUBLIC_SUPABASE_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY
+SUPABASE_SERVICE_ROLE_KEY
+PICA_SECRET_KEY
+PICA_STRIPE_CONNECTION_KEY
+```
+
+You may also update `.env.production` with the same keys when deploying to
+production.


### PR DESCRIPTION
## Summary
- add Supabase and Pica env vars to `.env.example`
- mirror the placeholders in `.env.production`
- document required keys in README

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840417d633c83289faf879c413742f8