### PR TITLE
Fix hydration mismatches

### DIFF
--- a/src/components/InvoicePromptInput.tsx
+++ b/src/components/InvoicePromptInput.tsx
@@ -139,28 +139,33 @@ export default function InvoicePromptInput({
   ];
 
   // Date suggestions - next few months
-  const dateSuggestions = [
-    {
-      label: "Today",
-      value: formatDate(new Date()),
-    },
-    {
-      label: "End of month",
-      value: formatDate(
-        new Date(new Date().getFullYear(), new Date().getMonth() + 1, 0),
-      ),
-    },
-    {
-      label: "Next month",
-      value: formatDate(
-        new Date(new Date().getFullYear(), new Date().getMonth() + 2, 0),
-      ),
-    },
-    {
-      label: "In 30 days",
-      value: formatDate(new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)),
-    },
-  ];
+  type DateSuggestion = { label: string; value: string };
+
+  const [dateSuggestions, setDateSuggestions] = useState<DateSuggestion[]>([]);
+
+  useEffect(() => {
+    const now = new Date();
+    const suggestions: DateSuggestion[] = [
+      {
+        label: "Today",
+        value: formatDate(now),
+      },
+      {
+        label: "End of month",
+        value: formatDate(new Date(now.getFullYear(), now.getMonth() + 1, 0)),
+      },
+      {
+        label: "Next month",
+        value: formatDate(new Date(now.getFullYear(), now.getMonth() + 2, 0)),
+      },
+      {
+        label: "In 30 days",
+        value: formatDate(new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)),
+      },
+    ];
+
+    setDateSuggestions(suggestions);
+  }, []);
 
   function formatDate(date: Date): string {
     return `${date.getDate().toString().padStart(2, "0")}/${(date.getMonth() + 1).toString().padStart(2, "0")}/${date.getFullYear()}`;

--- a/src/components/StripeDiagnosticsClient.tsx
+++ b/src/components/StripeDiagnosticsClient.tsx
@@ -1,14 +1,21 @@
 "use client";
 
+import React from "react";
 import EdgeFunctionDeploymentStatus from "@/components/EdgeFunctionDeploymentStatus";
 
 export default function StripeDiagnosticsClient() {
+  const [lastUpdated, setLastUpdated] = React.useState("");
+
+  React.useEffect(() => {
+    setLastUpdated(new Date().toLocaleString());
+  }, []);
+
   return (
     <div className="container mx-auto py-12 px-4 bg-white">
       <h1 className="text-3xl font-bold mb-8 text-center">
         Stripe API Diagnostics
         <span className="text-xs text-gray-500 block mt-2">
-          Last updated: {new Date().toLocaleString()}
+          Last updated: {lastUpdated}
         </span>
       </h1>
 


### PR DESCRIPTION
## Summary
- generate date suggestions on mount
- update Stripe diagnostics info with a client-safe timestamp

## Testing
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_684146fdb3948328b321014689c2cd43